### PR TITLE
Add SandboxTesting console project

### DIFF
--- a/SandboxTesting/Program.cs
+++ b/SandboxTesting/Program.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace SandboxTesting
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            var buildMode = "Debug";
+            var headless = false;
+            var cleanup = true;
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                switch (args[i])
+                {
+                    case "--mode":
+                    case "-m":
+                        if (i + 1 < args.Length)
+                        {
+                            buildMode = args[++i];
+                        }
+                        break;
+                    case "--headless":
+                    case "-h":
+                        headless = true;
+                        break;
+                    case "--cleanup":
+                        cleanup = true;
+                        break;
+                    case "--no-cleanup":
+                        cleanup = false;
+                        break;
+                }
+            }
+
+            Console.WriteLine($"Build mode: {buildMode}");
+            Console.WriteLine($"Headless: {headless}");
+            Console.WriteLine($"Cleanup: {cleanup}");
+        }
+    }
+}

--- a/SandboxTesting/SandboxTesting.csproj
+++ b/SandboxTesting/SandboxTesting.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net48</TargetFramework>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <Platforms>x64</Platforms>
+    </PropertyGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Server\Server.csproj" />
+        <ProjectReference Include="..\Scripts\Scripts.csproj" />
+    </ItemGroup>
+</Project>

--- a/ServUO.sln
+++ b/ServUO.sln
@@ -28,6 +28,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scripts", "Scripts\Scripts.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Server.Tests", "Server.Tests\Server.Tests.csproj", "{E090530C-53F8-4571-A664-09A5EB75B5FF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SandboxTesting", "SandboxTesting\SandboxTesting.csproj", "{F61D8C9E-5DD7-4F0F-BA43-37058FBA0ACA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -50,6 +52,10 @@ Global
 		{E090530C-53F8-4571-A664-09A5EB75B5FF}.Debug|x64.Build.0 = Debug|Any CPU
 		{E090530C-53F8-4571-A664-09A5EB75B5FF}.Release|x64.ActiveCfg = Release|Any CPU
 		{E090530C-53F8-4571-A664-09A5EB75B5FF}.Release|x64.Build.0 = Release|Any CPU
+		{F61D8C9E-5DD7-4F0F-BA43-37058FBA0ACA}.Debug|x64.ActiveCfg = Debug|x64
+		{F61D8C9E-5DD7-4F0F-BA43-37058FBA0ACA}.Debug|x64.Build.0 = Debug|x64
+		{F61D8C9E-5DD7-4F0F-BA43-37058FBA0ACA}.Release|x64.ActiveCfg = Release|x64
+		{F61D8C9E-5DD7-4F0F-BA43-37058FBA0ACA}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add SandboxTesting .NET Framework console project
- wire up project references to Server and Scripts
- parse command line options for build mode, headless runs, and cleanup

## Testing
- `dotnet format` *(fails: Required references did not load for SandboxTesting or referenced project. Run `dotnet restore` prior to formatting.)*
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b17be61f6483299ad14dd4fc740c8f