### PR TITLE
Add compilation runner for sandbox testing

### DIFF
--- a/SandboxTesting/Compiler/CompilationRunner.cs
+++ b/SandboxTesting/Compiler/CompilationRunner.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace SandboxTesting.Compiler
+{
+    public static class CompilationRunner
+    {
+        public static CompilationResult Run(bool debug, bool cache)
+        {
+            var logBuilder = new StringBuilder();
+            var writer = new StringWriter(logBuilder);
+            var originalOut = Console.Out;
+            var originalErr = Console.Error;
+
+            Console.SetOut(writer);
+            Console.SetError(writer);
+
+            var watch = Stopwatch.StartNew();
+            bool success;
+            try
+            {
+                success = Server.ScriptCompiler.Compile(debug, cache);
+            }
+            catch (Exception e)
+            {
+                writer.WriteLine(e);
+                success = false;
+            }
+            finally
+            {
+                watch.Stop();
+                Console.SetOut(originalOut);
+                Console.SetError(originalErr);
+                writer.Dispose();
+            }
+
+            var log = logBuilder.ToString();
+            var errors = success
+                ? Array.Empty<string>()
+                : log.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+
+            return new CompilationResult
+            {
+                Success = success,
+                Errors = errors,
+                Duration = watch.Elapsed,
+                Log = log
+            };
+        }
+    }
+
+    public class CompilationResult
+    {
+        public bool Success { get; set; }
+
+        public string[] Errors { get; set; }
+
+        public TimeSpan Duration { get; set; }
+
+        public string Log { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add CompilationRunner to build scripts and capture output

## Testing
- `dotnet format` *(fails: Required references did not load for SandboxTesting or referenced project)*
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b17dd9fc7483299eb3bab2c00e0620