### PR TITLE
Add compilation runner for sandbox testing

### DIFF
--- a/SandboxTesting/Compiler/CompilationRunner.cs
+++ b/SandboxTesting/Compiler/CompilationRunner.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace SandboxTesting.Compiler
+{
+    public static class CompilationRunner
+    {
+        public static CompilationResult Run(bool debug, bool cache)
+        {
+            var logBuilder = new StringBuilder();
+            var writer = new StringWriter(logBuilder);
+            var originalOut = Console.Out;
+            var originalErr = Console.Error;
+
+            Console.SetOut(writer);
+            Console.SetError(writer);
+
+            var watch = Stopwatch.StartNew();
+            bool success;
+            try
+            {
+                success = Server.ScriptCompiler.Compile(debug, cache);
+            }
+            catch (Exception e)
+            {
+                writer.WriteLine(e);
+                success = false;
+            }
+            finally
+            {
+                watch.Stop();
+                Console.SetOut(originalOut);
+                Console.SetError(originalErr);
+                writer.Dispose();
+            }
+
+            var log = logBuilder.ToString();
+            var errors = success
+                ? Array.Empty<string>()
+                : log.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+
+            return new CompilationResult
+            {
+                Success = success,
+                Errors = errors,
+                Duration = watch.Elapsed,
+                Log = log
+            };
+        }
+    }
+
+    public class CompilationResult
+    {
+        public bool Success { get; set; }
+
+        public string[] Errors { get; set; }
+
+        public TimeSpan Duration { get; set; }
+
+        public string Log { get; set; }
+    }
+}

--- a/Scripts/Scripts.csproj
+++ b/Scripts/Scripts.csproj
@@ -1,34 +1,35 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFramework>net48</TargetFramework>
-		<OutputType>Library</OutputType>
-		<AssemblyName>Scripts</AssemblyName>
-		<RootNamespace>Server</RootNamespace>
-		<AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
-		<GenerateAssemblyInfo>False</GenerateAssemblyInfo>
-		<UseVSHostingProcess>False</UseVSHostingProcess>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-		<UseWindowsForms>True</UseWindowsForms>
-		<Platforms>x64</Platforms>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-		<OutputPath>..\</OutputPath>
-		<DefineConstants>TRACE;DEBUG;NEWTIMERS;ServUO</DefineConstants>
-		<DebugType>embedded</DebugType>
-	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-		<OutputPath>..\</OutputPath>
-		<DefineConstants>TRACE;NEWTIMERS;ServUO</DefineConstants>
-		<DebugType>none</DebugType>
-	</PropertyGroup>
-	<ItemGroup>
-		<Reference Include="System.Web" />
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\Server\Server.csproj" />
-		<ProjectReference Include="..\Ultima\Ultima.csproj" />
-	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-	</ItemGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net48</TargetFramework>
+        <OutputType>Library</OutputType>
+        <AssemblyName>Scripts</AssemblyName>
+        <RootNamespace>Server</RootNamespace>
+        <AppendTargetFrameworkToOutputPath>False</AppendTargetFrameworkToOutputPath>
+        <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+        <UseVSHostingProcess>False</UseVSHostingProcess>
+        <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+        <Platforms>x64</Platforms>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+        <OutputPath>..\\</OutputPath>
+        <DefineConstants>TRACE;DEBUG;NEWTIMERS;ServUO</DefineConstants>
+        <DebugType>embedded</DebugType>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+        <OutputPath>..\\</OutputPath>
+        <DefineConstants>TRACE;NEWTIMERS;ServUO</DefineConstants>
+        <DebugType>none</DebugType>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="System.Web" />
+        <Reference Include="System.Windows.Forms" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\\Server\\Server.csproj" />
+        <ProjectReference Include="..\\Ultima\\Ultima.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+        <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    </ItemGroup>
 </Project>

--- a/Server.Tests/CompilationRunnerTests.cs
+++ b/Server.Tests/CompilationRunnerTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using SandboxTesting.Compiler;
+using Xunit;
+
+namespace Server.Tests;
+
+public class CompilationRunnerTests
+{
+    [Fact]
+    public void Compilation_succeeds()
+    {
+        var previousDir = Directory.GetCurrentDirectory();
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+        try
+        {
+            Directory.SetCurrentDirectory(repoRoot);
+            var result = CompilationRunner.Run(debug: false, cache: false);
+
+            Assert.True(result.Success, string.Join(Environment.NewLine, result.Errors));
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(previousDir);
+        }
+    }
+}

--- a/Server.Tests/Server.Tests.csproj
+++ b/Server.Tests/Server.Tests.csproj
@@ -24,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Server/Server.csproj" />
+    <ProjectReference Include="../SandboxTesting/SandboxTesting.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add CompilationRunner to build scripts and capture output
- enable cross-platform script builds and test compilation via SandboxTesting project

## Testing
- `dotnet format --include Scripts/Scripts.csproj Server.Tests/Server.Tests.csproj Server.Tests/CompilationRunnerTests.cs`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b17dd9fc7483299eb3bab2c00e0620