### PR TITLE
support dotnet test

### DIFF
--- a/Tests/Server.Tests/Server.Tests.csproj
+++ b/Tests/Server.Tests/Server.Tests.csproj
@@ -7,10 +7,12 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <UseMonoRuntime>true</UseMonoRuntime>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />

--- a/changlog.md
+++ b/changlog.md
@@ -11,3 +11,5 @@
 - add Timer scheduling tests
 - add Timer priority change tests
 - add Timer start/stop tests
+- add install-testhost.sh for running net48 tests on Linux
+- update Server.Tests to use Mono runtime and latest test SDK

--- a/tasks.md
+++ b/tasks.md
@@ -5,9 +5,10 @@
 - [ ] review existing documentation
 - [x] add tests for Timer priority changes
 - [x] add tests for Timer start/stop behavior
-- [ ] resolve missing testhost for dotnet test
+- [x] resolve missing testhost for dotnet test
 - [ ] implement Publish 112 updates (veteran rewards, Royal Taste Tester armor, misc improvements)
 - [ ] integrate Publish 114 seasonal content (Jack o' Lantern styles, Trick or Treat drops, Huntmaster's Challenge)
 - [ ] implement Publish 117 high seas & Shrouded Sails event content
 - [ ] implement Publish 118 Treasures of the Shattered Sanctum and Huntmaster's Challenge quarry
 - [ ] add Publish 119 Eclipsed Dawn champion spawn and Arcane Outfitter system
+- [ ] automate testhost installation in CI

--- a/tools/install-testhost
+++ b/tools/install-testhost
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOTNET_ROOT="$(dirname $(readlink -f $(which dotnet)))"
+SDK_VERSION="$(dotnet --version)"
+HOST_DIR="$DOTNET_ROOT/sdk/$SDK_VERSION/TestHostNetFramework"
+
+if [ -f "$HOST_DIR/testhost.net48.exe" ]; then
+  echo "testhost.net48.exe already present"
+  exit 0
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+pushd "$TMP_DIR" >/dev/null
+curl -sSL https://www.nuget.org/api/v2/package/Microsoft.TestPlatform/17.8.0 -o package.zip
+unzip -q package.zip
+mkdir -p "$HOST_DIR"
+cp -r tools/net462/Common7/IDE/Extensions/TestPlatform/* "$HOST_DIR"
+popd >/dev/null
+
+echo "Installed testhost.net48.exe to $HOST_DIR"


### PR DESCRIPTION
## Summary
- configure Server.Tests to use Mono and latest test SDK
- add installer for missing net48 testhost
- log testhost setup in changelog and tasks

## Testing
- `dotnet test`
- `dotnet format Tests/Server.Tests/Server.Tests.csproj --verify-no-changes`


------
https://chatgpt.com/codex/tasks/task_e_68b517e31a7083298d7a5acf68ace90e