### PR TITLE
Automate testhost installation in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: csharp
 solution: ServUO.sln
 mono: latest
+
+install:
+  - ./tools/install-testhost
+
+script:
+  - dotnet test

--- a/changlog.md
+++ b/changlog.md
@@ -13,3 +13,4 @@
 - add Timer start/stop tests
 - add install-testhost.sh for running net48 tests on Linux
 - update Server.Tests to use Mono runtime and latest test SDK
+- automate testhost installation in CI

--- a/tasks.md
+++ b/tasks.md
@@ -11,4 +11,5 @@
 - [ ] implement Publish 117 high seas & Shrouded Sails event content
 - [ ] implement Publish 118 Treasures of the Shattered Sanctum and Huntmaster's Challenge quarry
 - [ ] add Publish 119 Eclipsed Dawn champion spawn and Arcane Outfitter system
-- [ ] automate testhost installation in CI
+- [x] automate testhost installation in CI
+- [ ] monitor testhost package for updates


### PR DESCRIPTION
## Summary
- install testhost automatically in CI and run tests
- document testhost automation in changelog and tasks

## Testing
- `dotnet format --verify-no-changes` (fails: whitespace formatting errors)
- `./tools/install-testhost`
- `dotnet test Tests/Server.Tests/Server.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b51b7921e48329aad48e30f7d78786